### PR TITLE
Fix deprecated BindTo usage in ttyrun-getty@.service.in.

### DIFF
--- a/systemd/ttyrun-getty@.service.in
+++ b/systemd/ttyrun-getty@.service.in
@@ -11,7 +11,7 @@
 [Unit]
 Description=TTYRun on %I
 Documentation=man:ttyrun(8) man:agetty(8)
-BindTo=dev-%i.device
+BindsTo=dev-%i.device
 After=dev-%i.device systemd-user-sessions.service plymouth-quit-wait.service
 After=rc-local.service
 Before=getty.target


### PR DESCRIPTION
BindTo was renamed to BindsTo in systemd back in v187 from July 2012.

Signed-off-by: Philipp Kern <pkern@debian.org>