### PR TITLE
zipl: Always build and link without PIE.

### DIFF
--- a/common.mak
+++ b/common.mak
@@ -218,6 +218,16 @@ endif
 export AS LD CC CPP AR NM STRIP OBJCOPY OBJDUMP INSTALL CFLAGS CXXFLAGS \
        LDFLAGS CPPFLAGS ALL_CFLAGS ALL_CXXFLAGS ALL_LDFLAGS ALL_CPPFLAGS
 
+ifneq ($(shell $(CC_SILENT) -dumpspecs 2>/dev/null | grep -e '[^f]no-pie'),)
+	NO_PIE_CFLAGS := -fno-pie
+	NO_PIE_LINKFLAGS := -no-pie
+	NO_PIE_LDFLAGS := -no-pie
+else
+	NO_PIE_CFLAGS :=
+	NO_PIE_LINKFLAGS :=
+	NO_PIE_LDFLAGS :=
+endif
+
 # Overwrite implicite makefile rules for having nice compile output
 %.o: %.c
 	$(CC) $(ALL_CPPFLAGS) $(ALL_CFLAGS) -c $< -o $@

--- a/zipl/boot/Makefile
+++ b/zipl/boot/Makefile
@@ -1,7 +1,7 @@
 # Common definitions
 include ../../common.mak
 
-CFLAGS_BOOT = -Os -g -I../include -D__ASSEMBLY__ \
+CFLAGS_BOOT = $(NO_PIE_CFLAGS) -Os -g -I../include -D__ASSEMBLY__ \
 	  -DS390_TOOLS_RELEASE=$(S390_TOOLS_RELEASE) \
 	  -fno-builtin -ffreestanding -fno-asynchronous-unwind-tables \
 	  -fno-delete-null-pointer-checks \
@@ -54,11 +54,11 @@ stage3.exec: head.o stage3.o kdump3.o libc.o sclp.o sclp_stage3.o \
 			}' \
 	); \
 	case $$STAGE in \
-		0) SFLAGS="-nostdlib -Wl,-Ttext,0";; \
-		1) SFLAGS="-nostdlib -Wl,-Ttext,0x18";; \
-		1b) SFLAGS="-nostdlib -Wl,-Ttext,0xE000";; \
-		2) SFLAGS="-nostdlib -Wl,-T,stage2.lds";; \
-		3) SFLAGS="-nostdlib -Wl,-T,stage3.lds";; \
+		0) SFLAGS="$(NO_PIE_LINKFLAGS) -nostdlib -Wl,-Ttext,0";; \
+		1) SFLAGS="$(NO_PIE_LINKFLAGS) -nostdlib -Wl,-Ttext,0x18";; \
+		1b) SFLAGS="$(NO_PIE_LINKFLAGS) -nostdlib -Wl,-Ttext,0xE000";; \
+		2) SFLAGS="$(NO_PIE_LINKFLAGS) -nostdlib -Wl,-T,stage2.lds";; \
+		3) SFLAGS="$(NO_PIE_LINKFLAGS) -nostdlib -Wl,-T,stage3.lds";; \
 	esac; \
 	$(LINK) $$SFLAGS -m64 $^ -o $@
 
@@ -77,7 +77,7 @@ stage3.exec: head.o stage3.o kdump3.o libc.o sclp.o sclp_stage3.o \
 		$< $@
 
 data.o: $(FILES)
-	$(LD) -r -b binary -o data.o $(FILES)
+	$(LD) $(NO_PIE_LDFLAGS) -r -b binary -o data.o $(FILES)
 
 data.h: data.o
 	rm -f data.h

--- a/zipl/src/Makefile
+++ b/zipl/src/Makefile
@@ -7,8 +7,8 @@ ALL_CPPFLAGS += -I../include -I../boot \
 	    -DZFCPDUMP_FS_RD=$(ZFCPDUMP_FS_RD) \
 	    -DZFCPDUMP_PART_IMAGE=$(ZFCPDUMP_PART_IMAGE) \
 	    -DZFCPDUMP_PART_RD=$(ZFCPDUMP_PART_RD) \
-	    -D_FILE_OFFSET_BITS=64
-ALL_LDFLAGS += -Wl,-z,noexecstack
+	    -D_FILE_OFFSET_BITS=64 $(NO_PIE_CFLAGS)
+ALL_LDFLAGS += -Wl,-z,noexecstack $(NO_PIE_LDFLAGS)
 
 libs =	$(rootdir)/libutil/libutil.a \
 	$(rootdir)/libu2s/libu2s.a


### PR DESCRIPTION
Compilers in Debian and Ubuntu default to enabling PIE for all binaries.
This is a poor fit for boot loader code that has strict requirements
for its layout. Hence always forcefully disable PIE.

Signed-off-by: Philipp Kern <pkern@debian.org>