### PR TITLE
zipl: remove invalid dasdview command line option

### DIFF
--- a/zipl/src/zipl_helper.device-mapper
+++ b/zipl/src/zipl_helper.device-mapper
@@ -623,7 +623,7 @@ sub get_dasd_info($)
 	my $type;
 	local *HANDLE;
 
-	open(HANDLE, "$dasdview -x -f  $dev 2>/dev/null|") or
+	open(HANDLE, "$dasdview -x $dev 2>/dev/null|") or
 		# dasdview returned with an error
 		return undef;
 	while (<HANDLE>) {


### PR DESCRIPTION
dasdview command does not accept the '-f' option so because of that the
command will always fail.

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>