### PR TITLE
vmur changes

### DIFF
--- a/vmur/vmur.8
+++ b/vmur/vmur.8
@@ -201,7 +201,7 @@ Synopsis:
 .IP "" 2
 punch|print [-fr] [-d dev_node]
 [-C class] [--form form] [--dest dest] [--dist distcode]
-[-t | -b sep.pad] [-u user] [-n node]
+[-t | -b sep.pad] [-u user] [-n node] [--tag data] [--wait]
 .br
       [-N name.type] [file]
 .PP
@@ -352,6 +352,21 @@ name rules (e.g. longer than 8 chars).
 .IP "" 4
 - If the Linux input file name is also omitted (that is data is read
 from standard input), then an error message is issued.
+.SP
+.IP "" 0
+\fB-w or --wait\fR
+.IP "" 2
+Access to ur devices is serilaized. Use the wait option to wait for
+the device to be available. Without this option, if the device is in use
+an error message is displayed and the process exits.
+.SP
+.IP "" 0
+\fB-T or --tag\fR
+.IP "" 2
+Up to 136 characters of information you want to associate with the specified
+spool file. The contents and format of this data are flexible; they are 
+the responsibility of the file originator and the end user.
+Do not use the --tag option with the --node option.
 .SP
 .SH punch/print arguments
 .SP

--- a/vmur/vmur.8
+++ b/vmur/vmur.8
@@ -201,9 +201,9 @@ Synopsis:
 .IP "" 2
 punch|print [-fr] [-d dev_node]
 [-C class] [--form form] [--dest dest] [--dist distcode]
-[-t | -b sep.pad] [-u user] [-n node] [--tag data] [--wait]
+[-t | -b sep.pad] [-u user] [-n node]
 .br
-      [-N name.type] [file]
+      [-N name.type] [--wait] [--tag data] [file]
 .PP
 Minimum abbreviation: pun/pr
 .PP
@@ -217,7 +217,7 @@ reader queue.
 The following command options are supported by \fBpunch/print\fR:
 .SP
 .IP "" 0
-\fB-f or --force\fR
+\fB-f\fR or \fB--force\fR
 .IP "" 2
 Specifies to automatically convert Linux input file name (or
 <name>.<type> as specified with --name) to a valid spool
@@ -226,20 +226,20 @@ Invalid characters are replaced by _(underscore) and both <name> and <type>
 are truncated to a length of maximal 8 characters.
 .SP
 .IP "" 0
-\fB-r or --rdr\fR
+\fB-r\fR or \fB--rdr\fR
 .IP "" 2
 Specifies that the punch or printer file
 is to be transferred to a reader.
 .SP
 .IP "" 0
-\fB-d or --device\fR
+\fB-d\fR or \fB--device\fR
 .IP "" 2
 Specifies the device node of the virtual punch or printer device.
 If omitted, /dev/vmpun-0.0.000d is assumed for punch,
 and /dev/vmprt-0.0.000e for printer.
 .SP
 .IP "" 0
-\fB-C or --class\fR
+\fB-C\fR or \fB--class\fR
 .IP "" 2
 Specifies the spool file class assigned to the spool files created on this punch
 or print.  The class value is a 1-character alphanumeric field whose values can be
@@ -274,7 +274,7 @@ If OFF or an asterisk (*) is specified, the distribution code of the spool file
 is reset to the distribution code in the system directory.
 .SP
 .IP "" 0
-\fB-t or --text\fR
+\fB-t\fR or \fB--text\fR
 .IP "" 2
 specifies to
 punch or print the input file as text file, that is perform ASCII-to-EBCDIC
@@ -285,7 +285,7 @@ for a printer. If an input line length exceeds 80 or 132 for punch
 or print, respectively, an error message is issued.
 .SP
 .IP "" 0
-\fB-b or --blocked\fR
+\fB-b\fR or \fB--blocked\fR
 .IP "" 2
 Specifies that the file is to be written using blocked mode.
 As parameter for the -b option, the
@@ -304,7 +304,7 @@ output can be piped to punch or print, for example:
 # iconv xyz -f ISO-8859-1 -t EBCDIC-US | vmur pun -b 0x25,0x40 -N abc
 .SP
 .IP "" 0
-\fB-u or --user\fR
+\fB-u\fR or \fB--user\fR
 .IP "" 2
 Specifies the z/VM user ID to whose reader the data is to be
 transferred. The --user operand must adhere to z/VM user naming conventions.
@@ -317,7 +317,7 @@ If user is omitted, the data is transferred
 to your own machine's reader.
 .SP
 .IP "" 0
-\fB-n or --node\fR
+\fB-n\fR or \fB--node\fR
 .IP "" 2
 Specifies the z/VM node ID of a remote z/VM system to which
 the data is to be transferred. RSCS (Remote Spooling Communications
@@ -354,14 +354,14 @@ name rules (e.g. longer than 8 chars).
 from standard input), then an error message is issued.
 .SP
 .IP "" 0
-\fB-w or --wait\fR
+\fB-w\fR or \fB--wait\fR
 .IP "" 2
 Access to ur devices is serilaized. Use the wait option to wait for
 the device to be available. Without this option, if the device is in use
 an error message is displayed and the process exits.
 .SP
 .IP "" 0
-\fB-T or --tag\fR
+\fB-T\fR or \fB--tag\fR
 .IP "" 2
 Up to 136 characters of information you want to associate with the specified
 spool file. The contents and format of this data are flexible; they are 

--- a/vmur/vmur.cpp
+++ b/vmur/vmur.cpp
@@ -1903,7 +1903,7 @@ static void close_ur_device(struct vmur *info)
 	char cmd[MAXCMDLEN], spoolid[5] = {}, *response;
 	int cprc;
 
-	if (info->node_specified) {
+	if (info->node_specified || info->tag_specified) {
 		sprintf(cmd, "SPOOL %X NOCONT", info->devno);
 		cpcmd(cmd, NULL, NULL, 0);
 	}
@@ -2204,7 +2204,7 @@ static void ur_write(struct vmur *info)
 		fhi = STDIN_FILENO;
 	}
 
-	if (info->node_specified || '\0' != info->tag_data[0])
+	if (info->node_specified || info->tag_specified)
 		rscs_punch_setup(info);
 
 	/* Open UR device */

--- a/vmur/vmur.cpp
+++ b/vmur/vmur.cpp
@@ -2198,7 +2198,7 @@ static void ur_write(struct vmur *info)
 		fhi = STDIN_FILENO;
 	}
 
-	if (info->node_specified)
+	if (info->node_specified || '\0' != info->tag_data[0])
 		rscs_punch_setup(info);
 
 	/* Open UR device */

--- a/vmur/vmur.cpp
+++ b/vmur/vmur.cpp
@@ -594,7 +594,7 @@ static int require_spool_setup(struct vmur *info)
 		  info->spool_form_specified ||
 		  info->spool_dest_specified ||
 		  info->spool_dist_specified ||
-		  info->spool_tag_specified);
+		  info->tag_specified);
 }
 
 /*
@@ -1000,7 +1000,7 @@ static void parse_opts_punch_print(struct vmur *info, int argc, char *argv[])
 		{ "tag",         required_argument, NULL, 'T'},
 		{ 0,             0,                 0,    0  }
 	};
-	static const char option_string[] = "vhtrfwu:n:d:b:N:C:T:";
+	static const char option_string[] = "vhtrfwu:n:d:b:N:C:D:F:I:T:";
 
 	if (info->action == PUNCH) {
 		strcpy(info->devnode, VMPUN_DEVICE_NODE);
@@ -1079,7 +1079,7 @@ static void parse_opts_punch_print(struct vmur *info, int argc, char *argv[])
                         info->lock_attributes &= ~LOCK_NB;
 			break;	
 		case 'T':
-			++info->spool_tag_specified;
+			++info->tag_specified;
 			strncpy_graph(info->tag_data,optarg,sizeof(info->tag_data));			
                         break;
 		default:

--- a/vmur/vmur.cpp
+++ b/vmur/vmur.cpp
@@ -209,7 +209,7 @@ static char HELP_TEXT[] =
 "    --form               Form to be assigned to the created spool file.\n"
 "    --dest               Destination to be assigned to the created spool file.\n"
 "    --dist               Distribution code for the resulting spool file.\n"
-"-w, --wait               Wait for the specified to be free rather than getting\n"
+"-w, --wait               Wait for the specified device to be free rather than getting\n"
 "                         vmur in use error.\n"
 "-T, --tag                Up to 136 characters of information to associate with the\n"
 "                         spool file. The contents and format of this data are\n"
@@ -985,6 +985,7 @@ static void parse_opts_punch_print(struct vmur *info, int argc, char *argv[])
 		{ "text",        no_argument,       NULL, 't'},
 		{ "rdr",         no_argument,       NULL, 'r'},
 		{ "force",       no_argument,       NULL, 'f'},
+		{ "wait",	 no_argument,	    NULL, 'w'},
 		{ "user",        required_argument, NULL, 'u'},
 		{ "node",        required_argument, NULL, 'n'},
 		{ "device",      required_argument, NULL, 's'},
@@ -994,7 +995,6 @@ static void parse_opts_punch_print(struct vmur *info, int argc, char *argv[])
 		{ "dest",        required_argument, NULL, 'D'},
 		{ "form",        required_argument, NULL, 'F'},
 		{ "dist",	 required_argument, NULL, 'I'},
-		{ "wait",	 no_argument,	    NULL, 'w'},
 		{ "tag",         required_argument, NULL, "T"},
 		{ 0,             0,                 0,    0  }
 	};
@@ -1077,7 +1077,7 @@ static void parse_opts_punch_print(struct vmur *info, int argc, char *argv[])
                         info->lock_attributes &= ~LOCK_NB;
 			break;	
 		case 'T':
-			strncpy_graph(info->tag_data,optarg,(sizeof info->tag_data) - sizeof char);			
+			strncpy_graph(info->tag_data,optarg,sizeof info->tag_data);			
                         break;
 		default:
 			std_usage_exit();
@@ -2000,7 +2000,11 @@ static void rscs_punch_setup(struct vmur *info)
 
 	sprintf(cmd, "SPOOL %X CONT", info->devno);
 	cpcmd(cmd, NULL, NULL, 0);
-	sprintf(cmd, "TAG DEV %X %s %s", info->devno, info->node, info->user);
+	if ('\0' != info->node[0]) {
+	        sprintf(cmd, "TAG DEV %X %s %s", info->devno, info->node, info->user);
+	} else {
+		sprintf(cmd,"TAG DEV %X %s", info->devno, info->tag_data);
+	}
 	cpcmd(cmd, NULL, NULL, 0);
 	return;
 }

--- a/vmur/vmur.cpp
+++ b/vmur/vmur.cpp
@@ -2185,7 +2185,7 @@ static void ur_write(struct vmur *info)
 
 	sfdata = (char *) malloc(info->ur_reclen * VMUR_REC_COUNT);
 	if (!sfdata)
-		ERR_EXIT("Could allocate memory for buffer (%i)\n",
+		ERR_EXIT("Could not allocate memory for buffer (%i)\n",
 			    info->ur_reclen);
 
 	/* Open Linux file */

--- a/vmur/vmur.cpp
+++ b/vmur/vmur.cpp
@@ -212,8 +212,8 @@ static char HELP_TEXT[] =
 "-w, --wait               Wait for the specified to be free rather than getting\n"
 "                         vmur in use error.\n"
 "-T, --tag                Up to 136 characters of information to associate with the\n"
-"                         specified spool file. The contents and format of this data are\n"
-"                         flexible; they ar ethe responsibility of the file originator\n"
+"                         spool file. The contents and format of this data are\n"
+"                         flexible; they are the responsibility of the file originator\n"
 "                         and the end user.\n"
 "\n"
 "Options for 'purge' command:\n"
@@ -1077,7 +1077,7 @@ static void parse_opts_punch_print(struct vmur *info, int argc, char *argv[])
                         info->lock_attributes &= ~LOCK_NB;
 			break;	
 		case 'T':
-			strncpy_graph(info->tag_data,optarg,sizeof info->tag_data);			
+			strncpy_graph(info->tag_data,optarg,(sizeof info->tag_data) - sizeof char);			
                         break;
 		default:
 			std_usage_exit();

--- a/vmur/vmur.cpp
+++ b/vmur/vmur.cpp
@@ -1478,7 +1478,7 @@ static void acquire_lock(struct vmur *info)
 	char failed_action[10] = {};
 	char lock_file[PATH_MAX];
 	
-        snprintf(lockfile,sizeof lock_file, "%s-%04x",LOCK_FILE,info->devno);
+        snprintf(lock_file,sizeof lock_file, "%s-%04x",LOCK_FILE,info->devno);
 	info->lock_fd = open(lock_file, O_RDONLY | O_CREAT, S_IRUSR);
 	if (info->lock_fd == -1) {
 		ERR("WARNING: Unable to open lock file %s, continuing "

--- a/vmur/vmur.cpp
+++ b/vmur/vmur.cpp
@@ -988,14 +988,14 @@ static void parse_opts_punch_print(struct vmur *info, int argc, char *argv[])
 		{ "wait",	 no_argument,	    NULL, 'w'},
 		{ "user",        required_argument, NULL, 'u'},
 		{ "node",        required_argument, NULL, 'n'},
-		{ "device",      required_argument, NULL, 's'},
+		{ "device",      required_argument, NULL, 'd'},
 		{ "blocked",     required_argument, NULL, 'b'},
 		{ "name",        required_argument, NULL, 'N'},
 		{ "class",       required_argument, NULL, 'C'},
 		{ "dest",        required_argument, NULL, 'D'},
 		{ "form",        required_argument, NULL, 'F'},
 		{ "dist",	 required_argument, NULL, 'I'},
-		{ "tag",         required_argument, NULL, "T"},
+		{ "tag",         required_argument, NULL, 'T'},
 		{ 0,             0,                 0,    0  }
 	};
 	static const char option_string[] = "vhtrfwu:n:d:b:N:C:T:";

--- a/vmur/vmur.cpp
+++ b/vmur/vmur.cpp
@@ -2370,12 +2370,12 @@ int main(int argc, char **argv)
 	if (atexit(cleanup_atexit_fn))
 		ERR_EXIT("Could not set up vmur session cleanup\n");
 
-	/* Acquire a lock to serialize concurrent vmur invocations */
-	acquire_lock(&vmur_info);
-
 	/* Retrieve ur device number */
 	setup_ur_device(&vmur_info);
 
+	/* Acquire a lock to serialize concurrent vmur invocations */
+	acquire_lock(&vmur_info);
+	
 	switch (vmur_info.action) {
 	case RECEIVE:
 		/* Setup spool options */

--- a/vmur/vmur.cpp
+++ b/vmur/vmur.cpp
@@ -302,10 +302,9 @@ static void cperr_exit(char *cpcmd, int cprc, char *buf)
 
 static void _cpcmd(char *cpcmd, char **resp, int *rc, int retry, int upper)
 {
-	int fd, len, cprc, bufsize = VMCP_BUFSIZE;
+	int fd, len, cprc, bufsize = VMCP_BUFSIZE, n;
 	char *buf;
 	char cmd[MAXCMDLEN];
-	size_t n;
 
 	len = strlen(cpcmd);
 	for (n = 0; n < len; n++) {

--- a/vmur/vmur.cpp
+++ b/vmur/vmur.cpp
@@ -305,8 +305,16 @@ static void _cpcmd(char *cpcmd, char **resp, int *rc, int retry, int upper)
 	int fd, len, cprc, bufsize = VMCP_BUFSIZE;
 	char *buf;
 	char cmd[MAXCMDLEN];
+	size_t n;
 
-	strcpy(cmd, cpcmd);
+	len = strlen(cpcmd);
+	for (n = 0; n < len; n++) {
+		if (!isprint(cpcmd[n]))
+			break;
+		cmd[n] = cpcmd[n];
+	}
+	cmd[n] = '\0';
+
 	if (upper)
 		to_upper(cmd);
 

--- a/vmur/vmur.cpp
+++ b/vmur/vmur.cpp
@@ -302,17 +302,17 @@ static void cperr_exit(char *cpcmd, int cprc, char *buf)
 
 static void _cpcmd(char *cpcmd, char **resp, int *rc, int retry, int upper)
 {
-	int fd, len, cprc, bufsize = VMCP_BUFSIZE, n;
+	int fd, len, cprc, bufsize = VMCP_BUFSIZE, i;
 	char *buf;
 	char cmd[MAXCMDLEN];
 
 	len = strlen(cpcmd);
-	for (n = 0; n < len; n++) {
-		if (!isprint(cpcmd[n]))
+	for (i = 0; i < len; i++) {
+		if (!isprint(cpcmd[i]))
 			break;
-		cmd[n] = cpcmd[n];
+		cmd[i] = cpcmd[i];
 	}
-	cmd[n] = '\0';
+	cmd[i] = '\0';
 
 	if (upper)
 		to_upper(cmd);

--- a/vmur/vmur.cpp
+++ b/vmur/vmur.cpp
@@ -1077,7 +1077,7 @@ static void parse_opts_punch_print(struct vmur *info, int argc, char *argv[])
                         info->lock_attributes &= ~LOCK_NB;
 			break;	
 		case 'T':
-			strncpy_graph(info->tag_data,optarg,sizeof info->tag_data);			
+			strncpy_graph(info->tag_data,optarg,sizeof(info->tag_data));			
                         break;
 		default:
 			std_usage_exit();
@@ -1478,7 +1478,7 @@ static void acquire_lock(struct vmur *info)
 	char failed_action[10] = {};
 	char lock_file[PATH_MAX];
 	
-        snprintf(lock_file,sizeof lock_file, "%s-%04x",LOCK_FILE,info->devno);
+        snprintf(lock_file,sizeof(lock_file), "%s-%04x",LOCK_FILE,info->devno);
 	info->lock_fd = open(lock_file, O_RDONLY | O_CREAT, S_IRUSR);
 	if (info->lock_fd == -1) {
 		ERR("WARNING: Unable to open lock file %s, continuing "


### PR DESCRIPTION
Hello,
I have have made some changes to the vmur program for working with zVM ur devices, specifically print and punch files. 

I added a --wait option so vmur will wiat for the lock file to become free, rather than show a "vmur in use" error.
I added a --tag option to allow more control over the tag data, it cannot be used with --node option.
I changed the lock file name to include the device number so different instances of vmur using different devices can proceed.
I added code to prevent command-injection and unwittingly running an unintended CP command. 
I added info to the man file for the options I added.

I'd appreciate your feedback on my changes and would like you include them in future releases of the s390-tools package.

The reason I made these changes is because I have linux processes that create JCL for submission to zOS systems. Though I could get the JCL there using --node MVSX --user JOB, that's not really accurate, and there's no mechanism to supply priority or RSCS options. Using the --tag option I can punch a file to --user RSCS --tag 'mvsx job 10 ( accmsg=no enqmsg=no finalmsg=no sentmsg=no )'

and of course the --wait option allows multiple processes submitting JCL to both run simulataneously and serialize properly on the using the virtual punch device.

Normally I submit the JCL to zOS over FTP to JES, but RSCS is a backup mechanism in case the FTP fails for some reason. It's all automated, so I can't have one submission work and another error out with "vmur is in use" :-)

Thanks for your consideration.
Donald Russell
Visa Inc