### PR TITLE
Improve basics in netboot example

### DIFF
--- a/netboot/mk-pxelinux-ramfs
+++ b/netboot/mk-pxelinux-ramfs
@@ -164,7 +164,6 @@ echo "$cmd: Making init script"
 # --- begin init script
 cat <<'EOF' > $builddir/init
 #!/bin/sh
-script="/sbin/pxeboot.script"
 /bin/mount -t devtmpfs none /dev
 /bin/mount -t proc none /proc
 /bin/mount -t sysfs none /sys
@@ -173,12 +172,7 @@ script="/sbin/pxeboot.script"
 /sbin/modprobe virtio_net
 /sbin/udhcpc -O pxeconffile -O pxepathprefix &
 
-while true
-do
-	${script}
-	/bin/sleep 1
-	echo "retry ${script}"
-done
+/sbin/pxeboot.script
 EOF
 # --- end init script
 chmod +x $builddir/init
@@ -305,16 +299,26 @@ cat <<'EOF' > $builddir/sbin/pxeboot.script
 
 set -e
 
+# Check if a valid pxe conf is available
+# so far a non configurable 600 sec timeout
+PXE_CONF=/etc/pxe.conf
+TIMEOUT=600
+WAITED=0
+echo "waiting for pxe config from DHCP (max $TIMEOUT sec)"
+while [ ! -f $PXE_CONF ]
+do
+    sleep 1
+    WAITED=$(($WAITED + 1))
+    if [ $WAITED -gt $TIMEOUT ]
+    then
+        echo Error waiting for PXE configuration from DHCP
+        exit
+    fi
+done
+
 # Source the DHCP-generated TFTP info
 # Currently we are just looking for siaddr
-PXE_CONF=/etc/pxe.conf
-if [ -f  $PXE_CONF ]
-then
-    . $PXE_CONF
-else
-    echo waiting for PXE configuration from DHCP
-    exit
-fi
+. $PXE_CONF
 
 # Retrieve the config (default only for now)
 CONFIGS=""

--- a/netboot/mk-pxelinux-ramfs
+++ b/netboot/mk-pxelinux-ramfs
@@ -164,6 +164,7 @@ echo "$cmd: Making init script"
 # --- begin init script
 cat <<'EOF' > $builddir/init
 #!/bin/sh
+script="/sbin/pxeboot.script"
 /bin/mount -t devtmpfs none /dev
 /bin/mount -t proc none /proc
 /bin/mount -t sysfs none /sys
@@ -174,8 +175,9 @@ cat <<'EOF' > $builddir/init
 
 while true
 do
-	/sbin/pxeboot.script
+	${script}
 	/bin/sleep 1
+	echo "retry ${script}"
 done
 EOF
 # --- end init script
@@ -310,7 +312,7 @@ if [ -f  $PXE_CONF ]
 then
     . $PXE_CONF
 else
-    echo waiting for PXE configuration
+    echo waiting for PXE configuration from DHCP
     exit
 fi
 
@@ -347,6 +349,7 @@ then
     set +e
     for c in $CONFIGS
     do
+	echo "fetching config pxelinux.cfg/$c from $siaddr"
 	if /usr/bin/tftp -g -l /tmp/config -r pxelinux.cfg/$c $siaddr
 	then
 	    break
@@ -370,11 +373,13 @@ then
     echo no kernel statement found in config
     exit
 else
+    echo fetch kernel $kernel from $siaddr
     /usr/bin/tftp -g -l /tmp/kernel -r $kernel $siaddr
 fi
 
 if [ -n "$initrd" ]
 then
+    echo fetch initrd $initrd from $siaddr
     /usr/bin/tftp -g -l /tmp/initrd -r $initrd $siaddr
     INITRD="--initrd=/tmp/initrd"
 else
@@ -388,6 +393,7 @@ else
     APPEND=""
 fi
 
+echo "Kexec load: kexec -l /tmp/kernel $INITRD $APPEND"
 kexec -l /tmp/kernel $INITRD $APPEND
 kexec -e
 EOF

--- a/netboot/mk-pxelinux-ramfs
+++ b/netboot/mk-pxelinux-ramfs
@@ -364,9 +364,9 @@ then
 fi
 
 # Simple config file parsing, only one entry allowed
-kernel=$(/bin/grep "^[[:space:]]*kernel" /tmp/config | sed "s/^[[:space:]]*kernel[[:space:]]*//")
-initrd=$(/bin/grep "^[[:space:]]*initrd" /tmp/config | sed "s/^[[:space:]]*initrd[[:space:]]*//")
-append=$(/bin/grep "^[[:space:]]*append" /tmp/config | sed "s/^[[:space:]]*append[[:space:]]*//")
+kernel=$(/bin/grep -i "^[[:space:]]*kernel" /tmp/config | sed "s/^[[:space:]]*kernel[[:space:]]*//I")
+initrd=$(/bin/grep -i "^[[:space:]]*initrd" /tmp/config | sed "s/^[[:space:]]*initrd[[:space:]]*//I")
+append=$(/bin/grep -i "^[[:space:]]*append" /tmp/config | sed "s/^[[:space:]]*append[[:space:]]*//I")
 
 if [ -z "$kernel" ]
 then

--- a/netboot/mk-pxelinux-ramfs
+++ b/netboot/mk-pxelinux-ramfs
@@ -386,15 +386,13 @@ else
     INITRD=""
 fi
 
-if [ -n "$append" ]
-then
-    APPEND="--append=$append"
+if [ -z "$append" ]; then
+    echo "Kexec load: kexec -l /tmp/kernel $INITRD"
+    kexec -l /tmp/kernel $INITRD
 else
-    APPEND=""
+    echo "Kexec load: kexec -l /tmp/kernel $INITRD --append=\"$append\""
+    kexec -l /tmp/kernel $INITRD --append="$append"
 fi
-
-echo "Kexec load: kexec -l /tmp/kernel $INITRD $APPEND"
-kexec -l /tmp/kernel $INITRD $APPEND
 kexec -e
 EOF
 # -- end pxeboot script


### PR DESCRIPTION
Hi,
I know the mk-pxelinux-ramfs is menat as an example and note e.g. to implement full syslinux config.
But while testing with it there were a few thing that I considered low hanging fruits and therefore wanted to provide back to you.

It is mostly about the transparency of the PXE process for a user starting from it as well as fixing up some issues around the PXE config handling.