### PR TITLE
replace delimiter char in sed expressions

### DIFF
--- a/hmcdrvfs/Makefile
+++ b/hmcdrvfs/Makefile
@@ -49,7 +49,7 @@ install: all install-scripts
 install-scripts: lshmc
 	@for i in $^; do \
 		cat $$i | \
-		sed -e 's+%S390_TOOLS_VERSION%+$(S390_TOOLS_RELEASE)+' \
+		sed -e 's/%S390_TOOLS_VERSION%/$(S390_TOOLS_RELEASE)/' \
 		>$(DESTDIR)$(USRSBINDIR)/$$i; \
 		chown $(OWNER).$(GROUP) $(DESTDIR)$(USRSBINDIR)/$$i; \
 		chmod 755 $(DESTDIR)$(USRSBINDIR)/$$i; \

--- a/ip_watcher/Makefile
+++ b/ip_watcher/Makefile
@@ -8,7 +8,7 @@ clean:
 	rm -f *.o core xcec-bridge
 
 install: ip_watcher.pl xcec-bridge start_hsnc.sh
-	$(SED) -e 's+%S390_TOOLS_VERSION%+$(S390_TOOLS_RELEASE)+' \
+	$(SED) -e 's/%S390_TOOLS_VERSION%/$(S390_TOOLS_RELEASE)/' \
 	< start_hsnc.sh >$(DESTDIR)$(USRSBINDIR)/start_hsnc.sh; \
 	chown $(OWNER).$(GROUP) $(DESTDIR)$(USRSBINDIR)/start_hsnc.sh; \
 	chmod 755 $(DESTDIR)$(USRSBINDIR)/start_hsnc.sh; \

--- a/qethconf/Makefile
+++ b/qethconf/Makefile
@@ -3,7 +3,7 @@ include ../common.mak
 all:
 
 install: qethconf
-	$(SED) -e 's+%S390_TOOLS_VERSION%+$(S390_TOOLS_RELEASE)+' \
+	$(SED) -e 's/%S390_TOOLS_VERSION%/$(S390_TOOLS_RELEASE)/' \
 	< qethconf >$(DESTDIR)$(BINDIR)/qethconf; \
 	chown $(OWNER).$(GROUP) $(DESTDIR)$(BINDIR)/qethconf; \
 	chmod 755 $(DESTDIR)$(BINDIR)/qethconf; \

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -10,13 +10,13 @@ install:
 	@for i in $(SCRIPTS); \
 	do \
 		cat $$i | \
-		sed -e 's+%S390_TOOLS_VERSION%+$(S390_TOOLS_RELEASE)+' \
+		sed -e 's/%S390_TOOLS_VERSION%/$(S390_TOOLS_RELEASE)/' \
 		>$(DESTDIR)$(BINDIR)/$$i; \
 		chown $(OWNER):$(GROUP) $(DESTDIR)$(BINDIR)/$$i; \
 		chmod 755 $(DESTDIR)$(BINDIR)/$$i; \
 	done
 
-	sed -e 's+%S390_TOOLS_VERSION%+$(S390_TOOLS_RELEASE)+' cpictl > \
+	sed -e 's/%S390_TOOLS_VERSION%/$(S390_TOOLS_RELEASE)/' cpictl > \
 		$(DESTDIR)$(TOOLS_LIBDIR)/cpictl
 	chown $(OWNER):$(GROUP) $(DESTDIR)$(TOOLS_LIBDIR)/cpictl
 	chmod 775 $(DESTDIR)$(TOOLS_LIBDIR)/cpictl

--- a/zconf/Makefile
+++ b/zconf/Makefile
@@ -23,7 +23,7 @@ install:	install-scripts install-manpages install-usrsbin-scripts $(SUB_DIRS)
 install-scripts:	$(SCRIPTS)
 	@for i in $^; do \
 		cat $$i | \
-		sed -e 's+%S390_TOOLS_VERSION%+$(S390_TOOLS_RELEASE)+' \
+		sed -e 's/%S390_TOOLS_VERSION%/$(S390_TOOLS_RELEASE)/' \
 		>$(DESTDIR)$(BINDIR)/$$i; \
 		chown $(OWNER).$(GROUP) $(DESTDIR)$(BINDIR)/$$i; \
 		chmod 755 $(DESTDIR)$(BINDIR)/$$i; \
@@ -32,7 +32,7 @@ install-scripts:	$(SCRIPTS)
 install-usrsbin-scripts:	$(USRSBIN_SCRIPTS)
 	@for i in $^; do \
 		cat $$i | \
-		sed -e 's+%S390_TOOLS_VERSION%+$(S390_TOOLS_RELEASE)+' \
+		sed -e 's/%S390_TOOLS_VERSION%/$(S390_TOOLS_RELEASE)/' \
 		>$(DESTDIR)$(USRSBINDIR)/$$i; \
 		chown $(OWNER).$(GROUP) $(DESTDIR)$(USRSBINDIR)/$$i; \
 		chmod 755 $(DESTDIR)$(USRSBINDIR)/$$i; \


### PR DESCRIPTION
Use a character, that can't be used in rpm Version and Release tag, as the delimiter
in sed expressions. A "plus" is allowed (https://twiki.cern.ch/twiki/bin/view/Main/RPMAndDebVersioning), we had a situation where it was used in Release (in %dist) and it broke the build with ````sed: -e expression #1, char 37: unknown option to `s'````