### PR TITLE
zipl: add BootLoaderSpec support

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,7 +1,7 @@
 include ../common.mak
 
-SCRIPTS	= dbginfo.sh zfcpdbf scsi_logging_level
-MAN_PAGES = dbginfo.sh.1 zfcpdbf.1
+SCRIPTS	= dbginfo.sh zfcpdbf zipl-switch-to-blscfg scsi_logging_level
+MAN_PAGES = dbginfo.sh.1 zfcpdbf.1 zipl-switch-to-blscfg.1
 
 all:
 

--- a/scripts/zipl-switch-to-blscfg
+++ b/scripts/zipl-switch-to-blscfg
@@ -1,0 +1,213 @@
+#!/bin/bash
+#
+# zipl-switch-to-blscfg - Switch zipl to use BootLoaderSpec configuration
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# s390-tools is free software; you can redistribute it and/or modify
+# it under the terms of the MIT license. See LICENSE for details.
+#
+
+readonly SCRIPTNAME="${0##*/}"
+
+declare -A zipl_to_bls
+zipl_to_bls["image"]="linux"
+zipl_to_bls["ramdisk"]="initrd"
+zipl_to_bls["parameters"]="options"
+
+print_error() {
+    echo "$1" >&2
+    exit 1
+}
+
+function on_exit() {
+    if ! rm -rf $TMP; then
+        echo "Delete temporary files failed!" >&2
+        exit 1
+    fi
+}
+
+if ! TMP="$(mktemp -d)"; then
+    print_error "Creating a temporary dir for config files failed!"
+fi
+
+trap 'on_exit' EXIT
+
+print_version() {
+    cat <<EOF
+${SCRIPTNAME}: version %S390_TOOLS_VERSION%
+Copyright Red Hat, Inc. 2018
+EOF
+}
+
+print_usage()
+{
+    print_version
+
+    cat <<EOF
+
+Usage: ${SCRIPTNAME} [OPTIONS]
+
+Switches the zipl boot-loader configuration to use BootLoaderSpec files.
+
+Options:
+
+	-h, --help		print this help and exit
+	-v, --version      	print version information and exit
+	--backup-suffix=SUFFIX  suffix used for backup files, defaults to .bak
+	--bls-directory=DIR     path to generate BLS files, defaults to /boot/loader/entries
+	--config-file=FILE      path to zipl configuration file, defaults to /etc/zipl.conf
+	--ignore-default	ignore the default option from the zipl configuration file
+	--use-version-name	use the section kernel version as the BLS file name
+
+EOF
+}
+
+OPTS="$(getopt -o hv --long help,version,backup-suffix:,bls-directory:,config-file:,\
+ignore-default,use-version-name -n \'$SCRIPTNAME\' -- "$@")"
+eval set -- "$OPTS"
+
+BACKUP_SUFFIX=.bak
+BLS_DIR="/boot/loader/entries"
+CMDLINE_LINUX_DEBUG=" systemd.log_level=debug systemd.log_target=kmsg"
+LINUX_DEBUG_VERSION_POSTFIX="_with_debugging"
+LINUX_DEBUG_TITLE_POSTFIX=" with debugging"
+CONFIG="/etc/zipl.conf"
+
+while [ ${#} -gt 0 ]; do
+    case "$1" in
+	--help|-h)
+	    print_usage
+	    exit 0
+	    ;;
+	--version|-v)
+	    print_version
+	    exit 0
+	    ;;
+	--backup-suffix)
+	    BACKUP_SUFFIX=${2}
+	    shift
+	    ;;
+	--bls-directory)
+	    BLS_DIR=${2}
+	    shift
+	    ;;
+	--config-file)
+	    CONFIG=${2}
+	    shift
+	    ;;
+	--ignore-default)
+	    ignore_default=true
+	    ;;
+	--use-version-name)
+	    version_name=true
+	    ;;
+	--)
+	    shift
+	    break
+	    ;;
+	*)
+	    echo >&2
+	    echo "${SCRIPTNAME}: invalid option \"${1}\"" >&2
+	    echo "Try '${SCRIPTNAME} --help' for more information" >&2
+	    echo >&2
+	    exit 1
+	    ;;
+    esac
+    shift
+done
+
+TMP_CONFIG="${TMP}/${CONFIG##*/}"
+
+[[ -d "$BLS_DIR" ]] || mkdir -m 0700 -p "$BLS_DIR"
+
+if [ -f /etc/machine-id ]; then
+    read MACHINE_ID < /etc/machine-id
+    MACHINE_ID=${MACHINE_ID}-
+fi
+
+count=0
+OUTPUT=""
+TARGET=""
+while IFS='= ' read key val; do
+    # for BLS the default kernel is always the latest one
+    if [[ $key == \#* ]] || [[ $key == "default" && $ignore_default == true ]]; then
+        continue
+    fi
+
+    # remove spaces
+    key="$(echo $key | sed -e 's/^[ \t"]*//;s/[ \t"]*$//')"
+
+    if [[ $key = \[*] ]]; then
+        if [[ $key == "[defaultboot]" ]]; then
+            OUTPUT=${TMP_CONFIG}
+            echo $key >> ${OUTPUT}
+        else
+            key="${key%\]}"
+            key="${key#\[}"
+            section=$key
+            OUTPUT=${BLS_DIR}/${MACHINE_ID}${section}.conf
+            if [ -f "${OUTPUT}" ]; then
+                print_error "BLS file ${OUTPUT} already exists"
+            fi
+        fi
+    elif [[ $val ]]; then
+        val="$(echo $val | sed -e 's/^[ \t"]*//;s/[ \t"]*$//')"
+        if [[ $key == "target" ]]; then
+            if [ -z ${TARGET} ]; then
+                echo $key=$val >> ${TMP_CONFIG}
+                TARGET=$val
+            else if [ "${TARGET}" != "${val}" ]; then
+                     print_error "BLS is only supported if all sections have the same target"
+                 fi
+            fi
+        else
+            if [ -n "${zipl_to_bls[$key]}" ]; then
+		if [[ $key = "image" && $version_name == true ]]; then
+                    if [[ $val = *"vmlinuz-"* ]]; then
+                        version="${val##*/vmlinuz-}"
+                    else
+                        version="${val##*/}"
+                    fi
+                    echo "version $version" >> ${OUTPUT}
+                    if [[ $version = *"rescue"* ]]; then
+                        FILENAME=${BLS_DIR}/${MACHINE_ID}0-rescue.conf
+                    else
+                        FILENAME=${BLS_DIR}/${MACHINE_ID}${version}.conf
+                    fi
+
+                    if [[ ${OUTPUT} != ${FILENAME} ]]; then
+			if [ -f "${FILENAME}" ]; then
+			    print_error "BLS file ${FILENAME} already exists"
+			fi
+                        mv ${OUTPUT} ${FILENAME}
+                        if [ ! $? -eq 0 ]; then
+                            print_error "Creating BLS file ${FILENAME} failed"
+                        fi
+                        OUTPUT=${FILENAME}
+                    fi
+		elif [[ $key = "image" ]]; then
+                    echo "version $section" >> ${OUTPUT}
+		fi
+
+                echo "${zipl_to_bls[$key]} ${val}" >> ${OUTPUT}
+            else
+                echo $key=$val >> ${TMP_CONFIG}
+            fi
+        fi
+    fi
+done < "${CONFIG}"
+
+if [ -f "${CONFIG}${BACKUP_SUFFIX}" ]; then
+    print_error "Backup file ${CONFIG}${BACKUP_SUFFIX} already exists"
+fi
+
+cp -af "${CONFIG}" "${CONFIG}${BACKUP_SUFFIX}"
+mv "${TMP_CONFIG}" "${CONFIG}"
+
+zipl > /dev/null
+if [ ! $? -eq 0 ]; then
+    mv "${CONFIG}${BACKUP_SUFFIX}" "${CONFIG}"
+fi
+
+exit 0

--- a/scripts/zipl-switch-to-blscfg.1
+++ b/scripts/zipl-switch-to-blscfg.1
@@ -1,0 +1,45 @@
+.TH ZIPL-SWITCH-TO-BLSCFG  1 "April 2018" "s390-tools"
+
+.SH NAME
+zipl-switch-to-blscfg \- Switch zipl to use BootLoaderSpec configuration
+
+.SH SYNOPSIS
+.br
+\fBzipl-switch-to-blscfg\fP [OPTIONS]
+.br
+\fBzipl-switch-to-blscfg\fP {\-h|\-v}
+
+.SH DESCRIPTION
+This script switches the zipl boot-loader configuration to use BootLoaderSpec files
+to define IPL sections. For each Linux kernel defined in the zipl.conf config file,
+a BLS fragment is generated in the BLS directory specified. Also, the zipl.conf is
+modified it only contains global configurations, all IPL sections comes from BLS.
+
+.SH OPTIONS
+.TP
+\fB\-h\fP, \fB\-\-help\fP
+Print this help and exit
+
+.TP
+\fB\-v\fP, \fB\-\-version\fP
+Print version information and exit
+
+.TP
+\fB\-\-backup-suffix <SUFFIX>\fP
+The suffix used for backup files, defaults to .bak.
+
+.TP
+\fB\-\-bls-directory <DIRECTORY>\fP
+The DIRECTORY where the BLS fragments will be generated. The directory is created if it doesn't exists, by default /boot/loader/entries is used.
+
+.TP
+\fB\-\-config-file <FILE>\fP
+The FILE used for zipl configuration file, defaults to /etc/zipl.conf.
+
+.TP
+\fB\-\-ignore-default\fP
+Ignore the default option from the zipl configuration file
+
+.TP
+\fB\-\-use-version-name\fP
+Use the section kernel version as the BLS file name

--- a/zipl/include/scan.h
+++ b/zipl/include/scan.h
@@ -119,6 +119,7 @@ extern enum scan_key_state scan_key_table[SCAN_SECTION_NUM][SCAN_KEYWORD_NUM];
 
 
 int scan_file(const char* filename, struct scan_token** array);
+int scan_bls(const char* blsdir, struct scan_token** token, int scan_size);
 void scan_free(struct scan_token* array);
 char* scan_keyword_name(enum scan_keyword_id id);
 int scan_check_defaultboot(struct scan_token* scan);

--- a/zipl/include/zipl.h
+++ b/zipl/include/zipl.h
@@ -43,6 +43,7 @@
 
 #define ZIPL_CONF_VAR			"ZIPLCONF"
 #define ZIPL_DEFAULT_CONF		"/etc/zipl.conf"
+#define ZIPL_DEFAULT_BLSDIR		"/boot/loader/entries"
 
 #define MENU_DEFAULT_PROMPT		0
 #define MENU_DEFAULT_TIMEOUT		0

--- a/zipl/man/zipl.8
+++ b/zipl/man/zipl.8
@@ -25,7 +25,7 @@ loading a data file to initialize named saved segments (NSS)
 Each of these operations is characterized by a boot configuration, i.e. a
 set of required parameters.
 .B zipl
-supports two ways of specifying a boot configuration:
+supports three ways of specifying a boot configuration:
 .IP "     -"
 .B command line:
 all parameters are provided through the command line switches described below.
@@ -37,6 +37,11 @@ parameters are provided by sections defined in a configuration file (see
 Using a configuration file, you can either specify a single boot configuration
 or a menu, i.e. a list of configurations from which users can choose at boot
 time.
+.IP "     -"
+.B BLS config files:
+boot configurations are specified using BootLoaderSpec (BLS) configuration files. The
+.BR zipl.conf (5)
+configuration file is still used to specify parameters or aditional boot configurations.
 .PP
 
 To use a single boot configuration section, provide its name as parameter to
@@ -116,6 +121,11 @@ Print version information, then exit.
 .BR "\-c <CONFIG FILE>" " or " "\-\-config=<CONFIG FILE>"
 Use the specified <CONFIG FILE>. If none is supplied, the environment
 variable ZIPLCONF is evaluated if set, otherwise /etc/zipl.conf is used.
+
+.TP
+.BR "\-b <BLS DIRECTORY>" " or " "\-\-blsdir=<BLS DIRECTORY>"
+Use the specified <BLS DIRECTORY> to parse BootLoaderSpec config files.
+If none is supplied, the /boot/loader/entries directory is used.
 
 .TP
 .BR "\-t <TARGET DIRECTORY>" " or " "\-\-target=<TARGET DIRECTORY>"

--- a/zipl/man/zipl.conf.5
+++ b/zipl/man/zipl.conf.5
@@ -117,6 +117,27 @@ timeout     = 0
 .br
 .PP
 
+.B BootLoaderSpec configuration files
+
+Another way to specify IPL sections is to use BLS config files. These are
+configuration files located by default at /boot/loader/entries, but another
+location can be specified using the '\-\-blsdir' option of zipl.
+
+.IP
+# An example for a BLS configuration file
+.br
+
+version 4.15.9
+.br
+linux /vmlinuz-4.15.9
+.br
+initrd /initramfs-4.15.9
+.br
+options root=/dev/dasda1 console=ttyS0
+.PP
+
+The location of the linux and initrd has to be specified relative to the boot partition. The BLS config files are only used to specify the IPL sections, a zipl.conf configuration files is still needed for global parameters.
+
 .B Boot menu
 
 The

--- a/zipl/src/job.c
+++ b/zipl/src/job.c
@@ -1732,7 +1732,7 @@ get_job_from_config_file(struct command_line* cmdline, struct job_data* job)
 	struct scan_token* new_scan;
 	char* filename;
 	char* source;
-	int rc;
+	int rc, scan_size;
 
 	/* Read configuration file */
 	if (cmdline->config != NULL) {
@@ -1750,10 +1750,10 @@ get_job_from_config_file(struct command_line* cmdline, struct job_data* job)
 		source = "";
 	}
 	printf("Using config file '%s'%s\n", filename, source);
-	rc = scan_file(filename, &scan);
-	if (rc) {
+	scan_size = scan_file(filename, &scan);
+	if (scan_size <= 0) {
 		error_text("Config file '%s'", filename);
-		return rc;
+		return scan_size;
 	}
 	if ((cmdline->menu == NULL) && (cmdline->section == NULL)) {
 		rc = scan_check_defaultboot(scan);

--- a/zipl/src/scan.c
+++ b/zipl/src/scan.c
@@ -538,9 +538,9 @@ scan_free(struct scan_token* array)
 
 #define INITIAL_ARRAY_LENGTH 40
 
-/* Scan file FILENAME for tokens. Upon success, return zero and set TOKEN
- * to point to a NULL-terminated array of scan_tokens, i.e. the token id
- * of the last token is 0. Return non-zero otherwise. */
+/* Scan file FILENAME for tokens. Upon success, return the number allocated
+ * tokens and set TOKEN to point to a NULL-terminated array of scan_tokens,
+ * i.e. the token id of the last token is 0. Return non-zero otherwise. */
 int
 scan_file(const char* filename, struct scan_token** token)
 {
@@ -623,11 +623,13 @@ scan_file(const char* filename, struct scan_token** token)
 		}
 	}
 	misc_free_file_buffer(&file);
-	if (rc)
+	if (rc) {
 		scan_free(array);
-	else
-		*token = array;
-	return rc;
+		return rc;
+	}
+
+	*token = array;
+	return size;
 }
 
 

--- a/zipl/src/zipl.c
+++ b/zipl/src/zipl.c
@@ -54,6 +54,7 @@ static const char* usage_text[] = {
 "-h, --help                      Print this help, then exit",
 "-v, --version                   Print version information, then exit",
 "-c, --config CONFIGFILE         Read configuration from CONFIGFILE",
+"-b, --blsdir BLSDIR             Parse BootLoaderSpec files from BLSDIR",
 "-t, --target TARGETDIR          Write bootmap file to TARGETDIR and install",
 "                                bootloader on device containing TARGETDIR",
 "    --targetbase BASEDEVICE     Install bootloader on BASEDEVICE",


### PR DESCRIPTION
The [BootLoaderSpec](https://www.freedesktop.org/wiki/Specifications/BootLoaderSpec/) (BLS) defines a file format for boot configurations, so bootloaders can parse these files and create their boot menu entries by using the information provided by them.

From Fedora 28 there will be an option to use BootLoaderSpec snippets to update the bootloader menu entries. This still won't be the default, but the idea is to use it as default once all the architectures are supported. So this pull-request adds BLS support to the zipl user-space tool.

This will allow to configure the boot items as drop-in files in a directory instead of having to parse and modify the zipl.conf file.

If the /boot/loader/entries exists and there are BLS files there, then these are parsed and configuration sections are added without the need to have these in a zipl.conf file. A different BLS directory can be specified from the command line using the --blsdir option.

It can be tested using a zipl.conf file with no boot configuration sections:

```
[defaultboot]
defaultauto
prompt=1
timeout=5
default=4.15.9-300.fc27.s390x
target=/boot
```
and BLS entries, for example `/boot/loader/entries/8ee920ff9a434127928b5c04a594d3d5-4.15.9-300.fc27.s390x.conf`:

```
title Fedora (4.15.9-300.fc27.s390x) 27 (Server Edition)
version 4.15.9-300.fc27.s390x
linux /boot/vmlinuz-4.15.9-300.fc27.s390x
initrd /boot/initramfs-4.15.9-300.fc27.s390x.img
options root=/dev/mapper/fedora-root rd.lvm.lv=fedora/root rd.lvm.lv=fedora/swap
id fedora-20170308173431-4.15.9-300.fc27.s390x
```

