### PR TITLE
compute the bootloader stage size to workaround PIE

### DIFF
--- a/zipl/src/boot.c
+++ b/zipl/src/boot.c
@@ -21,7 +21,7 @@
 #include "error.h"
 #include "misc.h"
 
-#define DATA_SIZE(x)	((size_t) (&_binary_##x##_bin_size))
+#define DATA_SIZE(x)	((size_t) (&_binary_##x##_bin_end - &_binary_##x##_bin_start))
 #define DATA_ADDR(x)	(&_binary_##x##_bin_start)
 
 #define STAGE2_MAX_SIZE		0x3000


### PR DESCRIPTION
This should allow building the user-space zipl correctly with PIE. Fedora embeds the hardening flags in the compiler and linker flags, so after fixing https://bugzilla.redhat.com/show_bug.cgi?id=1552661 zipl started to fail with "Error: Internal error: Size mismatch of FBA stage 0 loader".

The bootloader stages run during IPL are built with their own flags and converted to raw binaries. These binaries are then converted to ELF objects with objdump and linked together to create data.o and data.h files (see boot/Makefile). During the bin->ELF conversion 3 symbols are added - start, end and size. When zipl is built with PIE the "size" symbols is relocated and the comparisons in boot_check_data() fail. "size" is marked as ABS in readelf output, so maybe there is also a binutils/linker bug. At the end instead of using the provided "size" we compute that from the "end" and "start" pointers and all seems to work correctly.

The command line we use to build zipl (and the whole s390-tools) is
````
make CFLAGS="$(rpmbuild --eval %{build_cflags})" CXXFLAGS="$(rpmbuild --eval %{build_cflags})" LDFLAGS="$(rpmbuild --eval %{build_ldflags})" BINDIR=/usr/sbin DISTRELEASE=2.fc29 V=1
````