### PR TITLE
Adjust zdev modprobe path to be compatible with split-usr systems.

### DIFF
--- a/zdev/include/path.h
+++ b/zdev/include/path.h
@@ -20,7 +20,7 @@
 #define	UDEV_SUFFIX		".rules"
 
 #define	PATH_MODPROBE_CONF	"/etc/modprobe.d"
-#define PATH_MODPROBE		"/usr/sbin/modprobe"
+#define PATH_MODPROBE		"/sbin/modprobe"
 #define PATH_CCW_BUS		"/sys/bus/ccw"
 #define PATH_CCWGROUP_BUS	"/sys/bus/ccwgroup"
 #define PATH_UDEV_RULES		"/etc/udev/rules.d"


### PR DESCRIPTION
mk-pxelinux-ramfs, mod_fsstatd|procd.service, zfcpdump all use
/sbin/modprobe path. Adjust zdev to use that path as well. This works
universally on both usr-merge systems (e.g. Debian/Ubuntu with
usrmerge package installed), and split-usr systems alike
(Debian/Ubuntu current stable releases default).

Bug-Launchpad: https://bugs.launchpad.net/ubuntu/+source/s390-tools/+bug/1777600
Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>