### PR TITLE
cpacfstatsd.service: only run on LPARs.

### DIFF
--- a/systemd/cpacfstatsd.service.in
+++ b/systemd/cpacfstatsd.service.in
@@ -10,6 +10,7 @@
 [Unit]
 Description=CPACF statistics collection daemon process for Linux on System z
 Documentation=man:cpacfstatsd(8)
+ConditionVirtualization=no
 
 [Service]
 Type=forking


### PR DESCRIPTION
Add ConditionVirtualization=no to the service file such that it is
only started on LPARs. This service cannot run on z/VM nor KVM, and
fails resulting in a degraded boot.

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>