### PR TITLE
zdev/initramfs: add s390-tools- prefix to hook, due to conflicts.

### DIFF
--- a/zdev/initramfs/Makefile
+++ b/zdev/initramfs/Makefile
@@ -17,6 +17,6 @@ INITTOP := $(INITRAMFSDIR)/scripts/init-top
 ifeq ($(HAVE_INITRAMFS),1)
 install:
 	$(INSTALL) -m 755 -d $(DESTDIR)/$(HOOKDIR) $(DESTDIR)/$(INITTOP)
-	$(INSTALL) -m 755 hooks/zdev $(DESTDIR)/$(HOOKDIR)
-	$(INSTALL) -m 755 scripts/init-top/zdev $(DESTDIR)/$(INITTOP)
+	$(INSTALL) -m 755 hooks/s390-tools-zdev $(DESTDIR)/$(HOOKDIR)
+	$(INSTALL) -m 755 scripts/init-top/s390-tools-zdev $(DESTDIR)/$(INITTOP)
 endif

--- a/zdev/initramfs/hooks/s390-tools-zdev
+++ b/zdev/initramfs/hooks/s390-tools-zdev
@@ -5,7 +5,7 @@
 # s390-tools is free software; you can redistribute it and/or modify
 # it under the terms of the MIT license. See LICENSE for details.
 #
-# hooks/zdev
+# hooks/s390-tools-zdev
 #   This hook script adds files required to apply firmware-provided I/O
 #   configuration data during boot.
 #

--- a/zdev/initramfs/scripts/init-top/s390-tools-zdev
+++ b/zdev/initramfs/scripts/init-top/s390-tools-zdev
@@ -5,7 +5,7 @@
 # s390-tools is free software; you can redistribute it and/or modify
 # it under the terms of the MIT license. See LICENSE for details.
 #
-# scripts/init-top/zdev
+# scripts/init-top/s390-tools-zdev
 #   Parse the kernel command line for rd.zdev kernel parameters. These
 #   parameters are evaluated and used to configure z Systems specific devices.
 #


### PR DESCRIPTION
Unfortunately zdev hook already exists in Ubuntu, from an unrelated
project. ZFS uses zdev/zpool names, and ships a zdev hook to do ZFS
specific initialisation. It is available on s390x and thus results in
file-conflict upon installing both. Thus renaming this zdev hook to
s390-tools-zdev.

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>