### PR TITLE
zdev: Trigger generic_ccw devices on any kernel module loads.

### DIFF
--- a/zdev/src/generic_ccw.c
+++ b/zdev/src/generic_ccw.c
@@ -27,7 +27,7 @@
  */
 
 static struct ccw_subtype_data generic_ccw_data = {
-	.ccwdrv		= NULL,
+	.ccwdrv		= "*",
 	.mod		= NULL,
 };
 


### PR DESCRIPTION
Generic CCW device can use any driver, and the value of the driver is
not known ahead of time. To avoid the race between loading and binding
a kernel module, and devices added - retrigger generic-ccw devices on
any kernel module load.

Fixes https://github.com/ibm-s390-tools/s390-tools/issues/37

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>