### PR TITLE
zdev: Trigger generic_ccw devices on any kernel module loads.

### DIFF
--- a/zdev/include/ccw.h
+++ b/zdev/include/ccw.h
@@ -62,10 +62,12 @@ struct ccw_devinfo {
  * ccw_subtype_data - CCW subtype specific information
  * @ccwdrv: The name of the CCW device driver for this subtype
  * @mod: The name of the main kernel module for this subtype
+ * @any_driver: If set, the exact driver for this subtype are not known
  */
 struct ccw_subtype_data {
 	const char *ccwdrv;
 	const char *mod;
+	bool any_driver;
 };
 
 extern struct attrib ccw_attr_online;

--- a/zdev/src/generic_ccw.c
+++ b/zdev/src/generic_ccw.c
@@ -29,6 +29,7 @@
 static struct ccw_subtype_data generic_ccw_data = {
 	.ccwdrv		= NULL,
 	.mod		= NULL,
+	.any_driver     = true,
 };
 
 /* Check if there is a non-generic subtype in the CCW namespace that uses the

--- a/zdev/src/udev_ccw.c
+++ b/zdev/src/udev_ccw.c
@@ -140,7 +140,7 @@ exit_code_t udev_ccw_write_device(struct device *dev, bool autoconf)
 {
 	struct subtype *st = dev->subtype;
 	struct ccw_subtype_data *data = st->data;
-	const char *type = st->name, *drv = data->ccwdrv, *id = dev->id;
+	const char *type = st->name, *drv = data->any_driver ? "*" : data->ccwdrv, *id = dev->id;
 	struct device_state *state = autoconf ? &dev->autoconf :
 						&dev->persistent;
 	char *path, *cfg_label = NULL, *end_label = NULL;


### PR DESCRIPTION
Generic CCW device can use any driver, and the value of the driver is
not known ahead of time. To avoid the race between loading and binding
a kernel module, and devices added - retrigger generic-ccw devices on
any kernel module load.

Fixes https://github.com/ibm-s390-tools/s390-tools/issues/37
LP: #1794308

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>