### PR TITLE
zipl: use the BLS "title" field as the IPL section name

### DIFF
--- a/scripts/zipl-switch-to-blscfg
+++ b/scripts/zipl-switch-to-blscfg
@@ -150,6 +150,7 @@ while IFS='= ' read key val; do
             if [ -f "${OUTPUT}" ]; then
                 print_error "BLS file ${OUTPUT} already exists"
             fi
+            echo "title $section" >> ${OUTPUT}
         fi
     elif [[ $val ]]; then
         val="$(echo $val | sed -e 's/^[ \t"]*//;s/[ \t"]*$//')"

--- a/zipl/src/scan.c
+++ b/zipl/src/scan.c
@@ -701,7 +701,7 @@ scan_bls_field(struct misc_file_buffer *file, struct scan_token* scan,
 	file->buffer[key_end] = '\0';
 	file->buffer[val_end] = '\0';
 
-	if (strncmp("version", &file->buffer[key_start], key_end - key_start) == 0) {
+	if (strncmp("title", &file->buffer[key_start], key_end - key_start) == 0) {
 		scan_append_section_heading(scan, index, &file->buffer[val_start]);
 	}
 


### PR DESCRIPTION
Most bootloaders use the BootLoaderSpec "title" field to name the entries
in their boot menu. The zipl bootloader used the "version" field instead,
since it was wrongly assumed that the zipl boot menu didn't support names
that contained spaces, which are usually present in a BLS "title" field.

But this is not the case, names with space characters are supported by the
IPL and is just a constraint of the section heading in the zipl.conf file.

So to be consistent with all the other bootloaders, use the "title" field
also on zipl when populating the boot menu entries from BLS files.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>