### PR TITLE
support autoloading kernel pkey module

### DIFF
--- a/etc/modules-load.d/s390-pkey.conf
+++ b/etc/modules-load.d/s390-pkey.conf
@@ -1,0 +1,2 @@
+# Load protected key support module on s390 early at boot
+pkey


### PR DESCRIPTION
The module is loaded automatically based on CPU features, but it's still
too late in some use cases. Thus allow distros to use explicit loading.

See also: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=63c19be095d0f8eb8992674991e44b4228bd4179

Signed-off-by: Dan Horák <dan@danny.cz>

@ifranzki 