### PR TITLE
Passphrase options

### DIFF
--- a/zkey/keystore.h
+++ b/zkey/keystore.h
@@ -68,7 +68,8 @@ int keystore_list_keys(struct keystore *keystore, const char *name_filter,
 		       const char *volume_type);
 
 int keystore_cryptsetup(struct keystore *keystore, const char *volume_filter,
-			bool execute, const char *volume_type);
+			bool execute, const char *volume_type, const char *keyfile,
+	                size_t keyfile_offset, size_t keyfile_size, size_t tries);
 
 int keystore_crypttab(struct keystore *keystore, const char *volume_filter,
 		      const char *volume_type);

--- a/zkey/keystore.h
+++ b/zkey/keystore.h
@@ -68,7 +68,7 @@ int keystore_list_keys(struct keystore *keystore, const char *name_filter,
 		       const char *volume_type);
 
 int keystore_cryptsetup(struct keystore *keystore, const char *volume_filter,
-			bool execute, const char *volume_type, const char *keyfile,
+			bool execute, bool batch_mode, const char *volume_type, const char *keyfile,
 	                size_t keyfile_offset, size_t keyfile_size, size_t tries);
 
 int keystore_crypttab(struct keystore *keystore, const char *volume_filter,

--- a/zkey/zkey.1
+++ b/zkey/zkey.1
@@ -547,15 +547,15 @@ option to generate crypttab entries for the specified volume type only.
 .RB [ \-\-volume-type | \-t
 .IR type ]
 .RB [ \-\-run | \-r ]
-.RB [ \-\-key\-file | \-d
+.RB [ \-\-key\-file
 .IR file-name ]
-.RB [ \-\-keyfile\-offset | \-o
+.RB [ \-\-keyfile\-offset
 .IR bytes ]
-.RB [ \-\-keyfile\-size | \-L
+.RB [ \-\-keyfile\-size
 .IR bytes ]
-.RB [ \-\-tries | \-T
+.RB [ \-\-tries
 .IR number ]
-.RB [ \-\-batch\-mode | \-q ]
+.RB [ \-\-batch\-mode]
 .RB [ \-\-verbose | \-V ]
 .
 .PP
@@ -983,30 +983,30 @@ Runs the generated cryptsetup commands. When one of the cryptsetup command fail,
 no further cryptsetup commands are run, and zkey ends with an error.
 This option is only used for secure keys contained in the secure key repository.
 .TP
-.BR \-d ", " \-\-key\-file\~\fIfile\-name\fP
+.BR \-\-key\-file\~\fIfile\-name\fP
 Reads the passphrase from the specified file. If this option is omitted,
 or if the file\-name is \fI-\fP (a dash), then you are prompted to enter the
 passphrase interactively.
 .TP
-.BR \-o ", " \-\-keyfile\-offset\~\fIbytes\fP
+.BR \-\-keyfile\-offset\~\fIbytes\fP
 Specifies the number of bytes to skip before starting to read in the file
 specified with option \fB\-\-key\-file\fP. If omitted, the file is read
 from the beginning. When option \fB\-\-key\-file\fP is not specified, this
 option is ignored.
 .TP
-.BR \-L ", " \-\-keyfile\-size\~\fIbytes\fP
+.BR \-\-keyfile\-size\~\fIbytes\fP
 Specifies the number of bytes to be read from the beginning of the file
 specified with option \fB\-\-key\-file\fP. If omitted, the file is read
 until the end. When \fB\-\-keyfile\-offset\fP is also specified, reading starts
 at the offset. When option \fB\-\-key\-file\fP is not specified, this option is
 ignored.
 .TP
-.BR \-T ", " \-\-tries\~\fInumber\fP
+.BR \-\-tries\~\fInumber\fP
 Specifies how often the interactive input of the passphrase can be re-entered.
 The default is 3 times. When option \fB\-\-key\-file\fP is specified, this
 option is ignored, and the passphrase is read only once from the file.
 .TP
-.BR \-q ", " \-\-batch\-mode
+.BR \-\-batch\-mode
 Suppress cryptsetup confirmation questions.
 .
 .

--- a/zkey/zkey.1
+++ b/zkey/zkey.1
@@ -547,6 +547,15 @@ option to generate crypttab entries for the specified volume type only.
 .RB [ \-\-volume-type | \-t
 .IR type ]
 .RB [ \-\-run | \-r ]
+.RB [ \-\-key\-file | \-d
+.IR file-name ]
+.RB [ \-\-keyfile\-offset | \-o
+.IR bytes ]
+.RB [ \-\-keyfile\-size | \-L
+.IR bytes ]
+.RB [ \-\-tries | \-T
+.IR number ]
+.RB [ \-\-batch\-mode | \-q ]
 .RB [ \-\-verbose | \-V ]
 .
 .PP
@@ -575,7 +584,24 @@ password based key derivation function, but this might cause out-of-memory
 errors when multiple encrypted volumes are unlocked automatically at boot
 through /etc/crypttab. Because PAES uses secure AES keys as volume keys, the
 security of the key derivation function used to encrypt the volume key in the
-LUKS key slots is of less relevance. 
+LUKS key slots is of less relevance.
+.P
+For LUKS2 volumes, a passphrase is required. You are prompted for the
+passphrase, unless option
+.B \-\-key\-file
+is specified. Option
+.B \-\-tries
+specifies how often a passphrase can be re-entered. When option
+.B \-\-key\-file
+is specified, the passphrase is read from the specified file. You can specify
+options
+.B \-\-keyfile\-offset
+and
+.B \-\-keyfile\-size
+to control which part of the key file is used as passphrase. To avoid confirmation
+question, one can specify
+.B \-\-batch\-mode
+option. These options behave in the same way as with \fBcryptsetup\fP.
 .
 .
 .
@@ -956,6 +982,32 @@ This option is only used for secure keys contained in the secure key repository.
 Runs the generated cryptsetup commands. When one of the cryptsetup command fail,
 no further cryptsetup commands are run, and zkey ends with an error.
 This option is only used for secure keys contained in the secure key repository.
+.TP
+.BR \-d ", " \-\-key\-file\~\fIfile\-name\fP
+Reads the passphrase from the specified file. If this option is omitted,
+or if the file\-name is \fI-\fP (a dash), then you are prompted to enter the
+passphrase interactively.
+.TP
+.BR \-o ", " \-\-keyfile\-offset\~\fIbytes\fP
+Specifies the number of bytes to skip before starting to read in the file
+specified with option \fB\-\-key\-file\fP. If omitted, the file is read
+from the beginning. When option \fB\-\-key\-file\fP is not specified, this
+option is ignored.
+.TP
+.BR \-L ", " \-\-keyfile\-size\~\fIbytes\fP
+Specifies the number of bytes to be read from the beginning of the file
+specified with option \fB\-\-key\-file\fP. If omitted, the file is read
+until the end. When \fB\-\-keyfile\-offset\fP is also specified, reading starts
+at the offset. When option \fB\-\-key\-file\fP is not specified, this option is
+ignored.
+.TP
+.BR \-T ", " \-\-tries\~\fInumber\fP
+Specifies how often the interactive input of the passphrase can be re-entered.
+The default is 3 times. When option \fB\-\-key\-file\fP is specified, this
+option is ignored, and the passphrase is read only once from the file.
+.TP
+.BR \-q ", " \-\-batch\-mode
+Suppress cryptsetup confirmation questions.
 .
 .
 .

--- a/zkey/zkey.c
+++ b/zkey/zkey.c
@@ -71,6 +71,7 @@ static struct zkey_globals {
 	char *volume_type;
 	char *newname;
 	bool run;
+	bool batch_mode;
 	char *keyfile;
 	long long keyfile_offset;
 	long long keyfile_size;
@@ -584,6 +585,11 @@ static struct util_opt opt_vec[] = {
 	{
 		.option = {"run", 0, NULL, 'r'},
 		.desc = "Runs the generated cryptsetup command",
+		.command = COMMAND_CRYPTSETUP,
+	},
+	{
+		.option = {"batch-mode", 0, NULL, 'q'},
+		.desc = "Suppresses cryptsetup confirmation questions",
 		.command = COMMAND_CRYPTSETUP,
 	},
 	{
@@ -1411,7 +1417,7 @@ static int command_cryptsetup(void)
 {
 	int rc;
 
-	rc = keystore_cryptsetup(g.keystore, g.volumes, g.run, g.volume_type, g.keyfile, g.keyfile_offset, g.keyfile_size, g.tries);
+	rc = keystore_cryptsetup(g.keystore, g.volumes, g.run, g.batch_mode, g.volume_type, g.keyfile, g.keyfile_offset, g.keyfile_size, g.tries);
 
 	return rc != 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 }
@@ -1611,6 +1617,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'r':
 			g.run = 1;
+			break;
+		case 'q':
+			g.batch_mode = 1;
 			break;
 		case 'L':
 			g.keyfile_size = strtoll(optarg, &endp, 0);


### PR DESCRIPTION
This adds the common passphrase options to `zkey cryptsetup` subcommand, as well as adds the `-batch-mode` option.

Unfortunately, I was not able to reuse the args with the `zkey-cryptsetup` command, due to `-l` clash... it's both `--volumes` and `--keyfile-size`, hence made it use `-L` short arg.

Fixes https://github.com/ibm-s390-tools/s390-tools/issues/58