### PR TITLE
zipl: update stage3 objcopy command for gcc9

### DIFF
--- a/zipl/boot/Makefile
+++ b/zipl/boot/Makefile
@@ -86,6 +86,7 @@ stage3.bin:	stage3.exec
 		--only-section=.ex_table \
 		--only-section=.data \
 		--only-section=.rodata.str1.2 \
+		--only-section=.rodata.cst8 \
 		--only-section=.rodata \
 		--only-section=.stage2dump.tail \
 		--only-section=.eckd2dump_mv.tail \


### PR DESCRIPTION
The objcopy command for stage3.bin needs to take the new rodata section into account.
See also PR #60.

Signed-off-by: Dan Horák <dan@danny.cz>