### PR TITLE
zipl: remove trailing spaces from the fields defined in BLS files

### DIFF
--- a/zipl/src/scan.c
+++ b/zipl/src/scan.c
@@ -699,6 +699,10 @@ scan_bls_field(struct misc_file_buffer *file, struct scan_token* scan,
 	}
 
 	val_end = file->pos;
+
+	while (val_end > val_start && isblank(file->buffer[val_end - 1]))
+		val_end--;
+
 	file->buffer[key_end] = '\0';
 	file->buffer[val_end] = '\0';
 
@@ -780,6 +784,7 @@ scan_bls(const char* blsdir, struct scan_token** token, int scan_size)
 			case EOF:
 				break;
 			case '\t':
+			case '\n':
 			case '\0':
 			case ' ':
 				file.pos++;


### PR DESCRIPTION
Currently the zipl tool doesn't remove trailing spaces from the BLS field
values. So for example if a 'title' field has trailing spaces and is used
as the default, zipl will complain that there's no section with that name:

Using config file '/etc/zipl.conf'
Using BLS config file '/boot/loader/entries/f871a0cf218348c5ba921f61c92b7eac-4.18.0-80.20.el8.s390x.conf'
Using BLS config file '/boot/loader/entries/f871a0cf218348c5ba921f61c92b7eac-0-rescue.conf'
Error: Config file '/etc/zipl.conf': Line 6: no such section 'Red Hat Enterprise Linux (4.18.0-80.20.el8.s390x) 8.1 (Ootpa)'

Since the trailing spaces are also removed from the fields defined in the
zipl.conf file, do the same for the ones that are defined in the BLS file.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>