### PR TITLE
Ftbfs stage3

### DIFF
--- a/zipl/boot/Makefile
+++ b/zipl/boot/Makefile
@@ -59,7 +59,7 @@ stage3.exec: head.o stage3.o kdump3.o libc.o sclp.o sclp_stage3.o \
 		2) SFLAGS="$(NO_PIE_LINKFLAGS) -nostdlib -Wl,-T,stage2.lds";; \
 		3) SFLAGS="$(NO_PIE_LINKFLAGS) -nostdlib -Wl,-T,stage3.lds";; \
 	esac; \
-	$(LINK) $$SFLAGS -m64 $^ -o $@
+	$(LINK) $$SFLAGS -m64 $(filter %.o, $^) -o $@
 
 %.bin:	%.exec
 	$(OBJCOPY) -O binary \

--- a/zipl/boot/Makefile
+++ b/zipl/boot/Makefile
@@ -46,7 +46,7 @@ stage3.exec: head.o stage3.o kdump3.o libc.o sclp.o sclp_stage3.o \
 	     kdump.o entry.o stage3.lds
 
 %.exec:	%.o
-	@STAGE=$$( \
+	STAGE=$$( \
 		echo $@ | awk ' \
 			match($$0,/[0-9]+b*/){ \
 				print substr($$0,RSTART,RLENGTH) \


### PR DESCRIPTION
zipl/boot/Makefile: fix failure to build, do not specify .lds twice.
    
Whilst stage3.lds is a dependency, it is specified via SFLAGS and must not be repeated again along all the .o files. Filter anything but .o files.

Fixes failure to build from source on Ubuntu 19.10.
    
Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/s390-tools/+bug/1833238