### PR TITLE
zipl: fix stage3 compilation error on newer binutils

### DIFF
--- a/zipl/boot/Makefile
+++ b/zipl/boot/Makefile
@@ -43,7 +43,7 @@ eckd2.exec: head.o stage2.o cio.o eckd2.o libc.o menu.o sclp.o \
 fba2.exec: head.o stage2.o cio.o fba2.o libc.o menu.o sclp.o \
 	   kdump2.o kdump.o entry.o
 stage3.exec: head.o stage3.o kdump3.o libc.o sclp.o sclp_stage3.o \
-	     kdump.o entry.o stage3.lds
+	     kdump.o entry.o
 
 %.exec:	%.o
 	@STAGE=$$( \


### PR DESCRIPTION
After binutils Bug 24576:

https://sourceware.org/bugzilla/show_bug.cgi?id=24576

and its fixes:

commit 6ec6968b1b259948ba42f0a47a3da048377058bc
Author: Nick Clifton <nickc@redhat.com>
Date:   Wed May 22 11:58:57 2019

    Have the linker report an error if the same script is used twice.

commit 82d7a6f4e3ccb3d714b5beb03eeb24f7356d4380
Author: Alan Modra <amodra@gmail.com>
Date:   Wed May 22 21:52:56 2019

    Re: Have the linker report an error if the same script is used twice

Makefile reports that stage3.lds is being given twice. This patch fixes
the issue to make stage 3 compilation to work in newer binutils.

Signed-off-by: Rafael David Tinoco <rafaeldtinoco@ubuntu.com>