### PR TITLE
systemd/cpi.service: Add RemainAfterExit=yes

### DIFF
--- a/systemd/cpi.service.in
+++ b/systemd/cpi.service.in
@@ -15,6 +15,7 @@ ConditionPathIsReadWrite=/sys/firmware/cpi
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 #
 # Specify a file with the environment variables using the EnvironmentFile=
 # service property.


### PR DESCRIPTION
Noticed this while looking at the unit file for a different
RHEL CoreOS issue.

See https://github.com/ostreedev/ostree/pull/1697
and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=750683

Omitting this can cause the service to run multiple times if
something else ends up depending on it, which I'm guessing
we don't want.

Signed-off-by: Colin Walters <walters@verbum.org>