### PR TITLE
zdev/dracut/95zdev/module-setup.sh: Add ctcm kernel module

### DIFF
--- a/zdev/dracut/95zdev/module-setup.sh
+++ b/zdev/dracut/95zdev/module-setup.sh
@@ -32,7 +32,7 @@ depends() {
 installkernel() {
     # Add modules for all device types supported by chzdev (required for
     # auto-configuration)
-    instmods lcs qeth qeth_l2 qeth_l3 dasd_mod dasd_eckd_mod dasd_fba_mod \
+    instmods ctcm lcs qeth qeth_l2 qeth_l3 dasd_mod dasd_eckd_mod dasd_fba_mod \
 	     dasd_diag_mod zfcp
 }
 


### PR DESCRIPTION
The module-setup.sh script doesn't include the ctcm module
when building the initrd. This causes any CTC devices to
be bound by the LCS driver instead.

Fix for bsc#1160373.

Signed-off-by: Mark Post <mpost@suse.com>