### PR TITLE
systemd/cpi.service: Add sysinit.target dependency to make sure /var is created

### DIFF
--- a/systemd/cpi.service.in
+++ b/systemd/cpi.service.in
@@ -10,7 +10,7 @@
 Description=Apply Control Program Identification (CPI)
 DefaultDependencies=no
 Conflicts=shutdown.target
-After=local-fs.target
+After=sysinit.target
 ConditionPathIsReadWrite=/sys/firmware/cpi
 
 [Service]


### PR DESCRIPTION
Noticed on RHEL CoreOS that the CPI service failed to start with :

"Cannot access lock file: /var/lock/cpictl.lock"

This was a timing issue where /var was not created yet and the symlink to /run/lock
was not present. Adding this as a suggestion from @cgwalters to fix this. This fix has been
tested with RHEL CoreOS.

Signed-off-by: Prashanth Sundararaman psundara@redhat.com