### PR TITLE
hsci: fix help text

### DIFF
--- a/hsci/hsci
+++ b/hsci/hsci
@@ -22,6 +22,7 @@ Usage: hsci COMMAND [OPTION]
 
 This tool is designed to control and show HSCI (HiperSockets Converged
 Interfaces) settings. A HiperSockets interface and an external network
+interface are converged into an HSCI interface.
 
 COMMANDS
         add HIPERSOCKETS_DEV NET_DEV    Adds an HSCI interface


### PR DESCRIPTION
Add the missing part of the sentence in the help text, taken from the man page.