### PR TITLE
fdasd: use same retries count (5) within `reread_partition_table` as used by dasdfmt

### DIFF
--- a/fdasd/fdasd.c
+++ b/fdasd/fdasd.c
@@ -1232,7 +1232,7 @@ static void fdasd_reread_partition_table(fdasd_anchor_t *anc)
 	if (!anc->silent)
 		printf("rereading partition table...\n");
 
-	if (dasd_reread_partition_table(options.device, 1) != 0) {
+	if (dasd_reread_partition_table(options.device, 5) != 0) {
 		fdasd_error(anc, unable_to_ioctl, "Error while rereading "
 			    "partition table.\nPlease reboot!");
 	}


### PR DESCRIPTION
To install Linux on uninitialized ECKD DASD disk
we use `dasdfmt` for low-level format and than `fdasd`
to create partitions, which sometimes fails with:

```
fdasd error:  IOCTL error: Error while rereading partition table.
```

This issue was observed during RHCOS installation on zVM with new DASD


Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>